### PR TITLE
#24 — Disable auto reconnect 

### DIFF
--- a/src/signalr/provider/index.ts
+++ b/src/signalr/provider/index.ts
@@ -13,6 +13,7 @@ function providerFactory<T extends Hub>(Context: Context<T>) {
   const Provider = ({
     url,
     connectEnabled = true,
+    automaticReconnect = true,
     children,
     dependencies = [],
     accessTokenFactory,
@@ -38,7 +39,7 @@ function providerFactory<T extends Hub>(Context: Context<T>) {
         accessTokenFactory: () => accessTokenFactoryRef.current?.() || "",
         logger,
         ...rest,
-      });
+      }, automaticReconnect);
 
       connection.onreconnecting((error) => onErrorRef.current?.(error));
       connection.onreconnected(() => onReconnect?.(connection));

--- a/src/signalr/provider/providerNativeFactory.ts
+++ b/src/signalr/provider/providerNativeFactory.ts
@@ -8,6 +8,7 @@ function providerNativeFactory<T extends Hub>(Context: Context<T>) {
   const Provider = ({
     url,
     connectEnabled = true,
+    automaticReconnect = true,
     children,
     dependencies = [],
     accessTokenFactory,
@@ -31,7 +32,7 @@ function providerNativeFactory<T extends Hub>(Context: Context<T>) {
       const connection = createConnection(url, {
         accessTokenFactory: () => accessTokenFactoryRef.current?.() || "",
         ...rest,
-      });
+      }, automaticReconnect);
       connection.onreconnecting((error) => onErrorRef.current?.(error));
       connection.onreconnected(() => onReconnect?.(connection));
 

--- a/src/signalr/provider/types.ts
+++ b/src/signalr/provider/types.ts
@@ -12,4 +12,5 @@ export interface ProviderProps extends IHttpConnectionOptions {
   onClosed?: (error?: Error) => void;
   onOpen?: (connection: HubConnection) => void;
   onReconnect?: (connection: HubConnection) => void;
+  automaticReconnect?: boolean;
 }

--- a/src/signalr/utils.ts
+++ b/src/signalr/utils.ts
@@ -13,10 +13,13 @@ function isConnectionConnecting(connection: HubConnection) {
   );
 }
 
-function createConnection(url: string, transportType: IHttpConnectionOptions) {
+function createConnection(url: string, transportType: IHttpConnectionOptions, automaticReconnect: boolean = true) {
   let connectionBuilder = new HubConnectionBuilder()
     .withUrl(url, transportType)
-    .withAutomaticReconnect();
+
+    if (automaticReconnect) {
+      connectionBuilder = connectionBuilder.withAutomaticReconnect();
+    }
 
   if (transportType.logger) {
     connectionBuilder = connectionBuilder.configureLogging(

--- a/src/socket/provider/index.ts
+++ b/src/socket/provider/index.ts
@@ -13,6 +13,7 @@ function providerFactory<T extends Hub>(Context: Context<T>) {
   const Provider = ({
     url,
     connectEnabled = true,
+    automaticReconnect = true,
     children,
     dependencies = [],
     accessTokenFactory,
@@ -31,6 +32,7 @@ function providerFactory<T extends Hub>(Context: Context<T>) {
 
       const connection = createConnection(url, {
         autoConnect: true,
+        reconnection: automaticReconnect,
         transportOptions: {
           polling: {
             extraHeaders: {

--- a/src/socket/provider/providerNativeFactory.ts
+++ b/src/socket/provider/providerNativeFactory.ts
@@ -8,6 +8,7 @@ function providerNativeFactory<T extends Hub>(Context: Context<T>) {
   const Provider = ({
     url,
     connectEnabled = true,
+    automaticReconnect = true,
     children,
     dependencies = [],
     accessTokenFactory,
@@ -28,6 +29,7 @@ function providerNativeFactory<T extends Hub>(Context: Context<T>) {
         extraHeaders: {
           Authorization: (await accessTokenFactoryRef.current?.()) || "",
         },
+        reconnection: automaticReconnect,
         ...rest,
       });
 

--- a/src/socket/provider/types.ts
+++ b/src/socket/provider/types.ts
@@ -15,4 +15,5 @@ export interface ProviderProps extends Partial<ManagerOptions & SocketOptions> {
    *     token, or a Promise that resolves to a string containing the access token.
    */
   accessTokenFactory?(): string | Promise<string>;
+  automaticReconnect?: boolean;
 }


### PR DESCRIPTION
The prop is available for `socket.io` and `signalR` Providers


```js
import { createSignalRContext } from "react-signalr";

const { useSignalREffect, Provider } = createSignalRContext();
// or createSocketIoContext() for socket.io

const App = () => {
  const { token } = YourAccessToken

  return (
    <SignalRContext.Provider
      connectEnabled={!!token}
      accessTokenFactory={() => token}
      dependencies={[token]} //remove previous connection and create a new connection if changed
      url={"https://example/hub"}
      automaticReconnect={false}
    >
      <Routes />
    </SignalRContext.Provider>
  );
};
```

This feature will keep old behavior as default, if you want to disable the automatic reconnect for `signalR` and `socket.io`, do it explicitly in the provider.